### PR TITLE
Make underlying consensus framework pluggable

### DIFF
--- a/src/riak_governor.erl
+++ b/src/riak_governor.erl
@@ -51,7 +51,7 @@ find_leader(Name, Nodes) ->
 do_find_leader(_IsLocal, _Name, []) ->
     {error, no_leader};
 do_find_leader(true, Name, Nodes) ->
-    case catch rafter:get_leader(Name) of
+    case catch riak_governor_spi:get_leader(Name) of
         {'EXIT', {noproc, _}} ->
             do_find_leader(false, Name, Nodes -- [node()]);
         {_, Result} ->
@@ -60,7 +60,7 @@ do_find_leader(true, Name, Nodes) ->
             {error, no_leader}
     end;
 do_find_leader(false, Name, [Node|Rest]) ->
-    case catch rafter:get_leader({Name, Node}) of
+    case catch riak_governor_spi:get_leader({Name, Node}) of
         {'EXIT', {noproc, _}} ->
             do_find_leader(false, Name, Rest);
         {_, Result} ->

--- a/src/riak_governor.hrl
+++ b/src/riak_governor.hrl
@@ -1,1 +1,2 @@
 -define(DEFAULT_ENSEMBLE_SIZE, 3).
+-define(DEFAULT_ENSEMBLE_PROVIDER, rafter).

--- a/src/riak_governor_ensemble_master.erl
+++ b/src/riak_governor_ensemble_master.erl
@@ -1,8 +1,6 @@
 -module(riak_governor_ensemble_master).
 -behaviour(gen_server).
 
--include_lib("rafter/include/rafter_opts.hrl").
-
 %% API
 -export([ring_changed/0]).
 -export([start_link/0]).
@@ -105,16 +103,4 @@ ensemble_started(Nodes) ->
 start_ensemble(Nodes) ->
     EnsembleName = riak_governor_util:ensemble_name(Nodes),
     Peers = lists:map(fun(Node) -> {EnsembleName, Node} end, Nodes),
-    start_node(EnsembleName, Peers).
-
-start_node(Name, Peers) ->
-    % TODO: configurable logdir
-    Me = {Name, node()},
-    Opts = #rafter_opts{state_machine=rafter_backend_ets, logdir="./data"},
-    case rafter:start_node(Me, Opts) of
-        {ok, _} ->
-            catch rafter:set_config(Name, Peers),
-            ok;
-        {error,{already_started,_}} ->
-            ok
-    end.
+    riak_governor_spi:start_ensemble(EnsembleName, Peers).

--- a/src/riak_governor_spi.erl
+++ b/src/riak_governor_spi.erl
@@ -1,0 +1,44 @@
+%% @doc This module defins a service provider behaviour enabling alternative
+%% distributed consensus algorithm implementations to be provided to riak_governor
+%%
+
+-module(riak_governor_spi).
+
+-export([get_leader/1]).
+-export([start_ensemble/2]).
+
+-callback get_leader(term()) -> {term(), node()}.
+-callback start_ensemble(term(),list()) -> ok | already_started.
+
+get_leader(Id) ->
+    Provider = riak_governor_util:get_ensemble_provider(),
+    get_leader(Provider,Id).
+
+start_ensemble(Name,Peers) ->
+    Provider = riak_governor_util:get_ensemble_provider(),
+    start_ensemble(Provider,Name,Peers).
+
+%%
+%% internal
+%%
+
+get_leader(rafter,{Id,Node}) ->
+    riak_governor_spi_rafter:get_leader({Id,Node});
+get_leader(rafter,Id) ->
+    riak_governor_spi_rafter:get_leader(Id);
+get_leader(riak_ensemble,{Id,_Node}) ->
+    riak_governor_spi_riak_ensemble:get_leader(Id);
+get_leader(riak_ensemble,Id) ->
+    riak_governor_spi_riak_ensemble:get_leader(Id);
+get_leader(_Otherwise,_Id) ->
+    throw(bad_ensemble_provider).
+
+start_ensemble(rafter,Name,Peers) ->
+    riak_governor_spi_rafter:start_ensemble(Name,Peers);
+start_ensemble(riak_ensemble,Name,Peers) ->
+    riak_governor_spi_riak_ensemble:start_ensemble(Name,Peers);
+start_ensemble(_Otherwise,_Name,_Peers) ->
+    throw(bad_ensemble_provider).
+
+
+

--- a/src/riak_governor_spi_rafter.erl
+++ b/src/riak_governor_spi_rafter.erl
@@ -1,0 +1,23 @@
+-module(riak_governor_spi_rafter).
+-behaviour(riak_governor_spi).
+
+-include_lib("rafter/include/rafter_opts.hrl").
+
+-export([get_leader/1]).
+-export([start_ensemble/2]).
+
+get_leader(Id) ->
+    rafter:get_leader(Id).
+
+start_ensemble(Name, Peers) ->
+    % TODO: configurable logdir
+    Me = {Name, node()},
+    Opts = #rafter_opts{state_machine=rafter_backend_ets, logdir="./data"},
+    case rafter:start_node(Me, Opts) of
+        {ok, _} ->
+            catch rafter:set_config(Name, Peers),
+            ok;
+        {error,{already_started,_}} ->
+            ok
+    end.
+

--- a/src/riak_governor_spi_riak_ensemble.erl
+++ b/src/riak_governor_spi_riak_ensemble.erl
@@ -1,0 +1,15 @@
+-module(riak_governor_spi_riak_ensemble).
+-behaviour(riak_governor_spi).
+
+-define(ENSEMBLE_BACKEND, riak_ensemble_basic_backend).
+
+-export([get_leader/1]).
+-export([start_ensemble/2]).
+
+get_leader(Id) ->
+    riak_ensemble_manager:get_leader(Id).
+
+start_ensemble(Name,Peers) ->
+    riak_ensemble_manager:create_ensemble(Name, {Name,node()}, Peers, ?ENSEMBLE_BACKEND, []),
+    ok.
+

--- a/src/riak_governor_util.erl
+++ b/src/riak_governor_util.erl
@@ -2,11 +2,14 @@
 
 -include("riak_governor.hrl").
 
--export([get_ensemble_size/0, ensemble_name/1]).
+-export([get_ensemble_size/0, get_ensemble_provider/0, ensemble_name/1]).
 -export([get_primary_apl/1]).
 
 get_ensemble_size() ->
     riak_governor:get_env(ensemble_size, ?DEFAULT_ENSEMBLE_SIZE).
+
+get_ensemble_provider() ->
+    riak_governor:get_env(ensemble_provider, ?DEFAULT_ENSEMBLE_PROVIDER).
 
 ensemble_name(Nodes) when is_list(Nodes) ->
     list_to_atom(lists:flatten(lists:map(fun erlang:atom_to_list/1, Nodes))).


### PR DESCRIPTION
Still needs tests. Not sure this should be in core where rafter is default
or part of the riak_test based test suite...
