### PR TITLE
fixing rafter dependency for external projects

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -3,7 +3,7 @@
 {deps, [
         {reltool_util, ".*", {git, "https://github.com/okeuday/reltool_util.git", {tag, "v1.4.0"}}},
         {riak_core, ".*", {git, "git://github.com/Regulators/riak_core", {tag,"2.0.1jb3"}}},
-        {rafter, ".*", {git, "https://github.com/andrewjstone/rafter.git", {tag, "0.2.1"}}}
+        {rafter, ".*", {git, "https://github.com/andrewjstone/rafter.git", "bef9c9b6c5d8cad14685b2f3045dd83d9915e513"}}
        ]}.
 
 {cover_enabled, true}.

--- a/rebar.config
+++ b/rebar.config
@@ -3,7 +3,7 @@
 {deps, [
         {reltool_util, ".*", {git, "https://github.com/okeuday/reltool_util.git", {tag, "v1.4.0"}}},
         {riak_core, ".*", {git, "git://github.com/Regulators/riak_core", {tag,"2.0.1jb3"}}},
-        {rafter, ".*", {git, "git@github.com:andrewjstone/rafter.git", {branch, "master"}}}
+        {rafter, ".*", {git, "https://github.com/andrewjstone/rafter.git", {tag, "0.2.1"}}}
        ]}.
 
 {cover_enabled, true}.


### PR DESCRIPTION
from git protocol to https, otherwise, external travis build fails with:
ERROR: 'get-deps' failed while processing /home/travis/build/konrads/rcr/deps/riak_governor: rebar_abort
