### PR TITLE
fix: #7 by retrying to create ensembles

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,9 +1,11 @@
 {sub_dirs, ["rel"]}.
 
+{erl_opts, [{parse_transform, lager_transform}]}.
+
 {deps, [
         {reltool_util, ".*", {git, "https://github.com/okeuday/reltool_util.git", {tag, "v1.4.0"}}},
         {riak_core, ".*", {git, "git://github.com/Regulators/riak_core", {tag,"2.0.1jb3"}}},
-        {rafter, ".*", {git, "git@github.com:andrewjstone/rafter.git", {branch, "master"}}}
+        {rafter, ".*", {git, "https://github.com/andrewjstone/rafter.git", "bef9c9b6c5d8cad14685b2f3045dd83d9915e513"}}
        ]}.
 
 {cover_enabled, true}.

--- a/src/riak_governor.app.src
+++ b/src/riak_governor.app.src
@@ -1,6 +1,6 @@
 {application, riak_governor, [
  {description, "Riak leader of the unique set of preflist owning nodes"},
  {vsn, "0.1.0"},
- {applications, [stdlib, kernel, riak_core, rafter]},
+ {applications, [stdlib, kernel, riak_core, rafter, lager]},
  {mod, {riak_governor_app, []}}
 ]}.

--- a/src/riak_governor_spi_riak_ensemble.erl
+++ b/src/riak_governor_spi_riak_ensemble.erl
@@ -12,6 +12,5 @@ get_leader(Id) ->
     riak_ensemble_manager:get_leader(Id).
 
 start_ensemble(Name,Peers) ->
-    riak_ensemble_manager:create_ensemble(Name, {Name,node()}, Peers, ?ENSEMBLE_BACKEND, []),
-    ok.
+    riak_ensemble_manager:create_ensemble(Name, {Name,node()}, Peers, ?ENSEMBLE_BACKEND, []).
 


### PR DESCRIPTION
if ensembles cannot be created, retries.  Implemented for riak_ensemble, rafter doesn not suffer from similar issues.  Is this a correct approach?
